### PR TITLE
Update backend.c

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -109,7 +109,7 @@ get_default_route(void)
 
 		if (retval != 11) continue;
 
-		if (gw == 0 && !is_dummy_device(device)) {
+		if (ip == 0 && !is_dummy_device(device)) {
 			fclose(fp);
 			return device;
 		}


### PR DESCRIPTION
Actually, a default route is defined by having the destination subnet to 0.0.0.0/0, not having the GW to 0 (which in any case, should be gw != 0).
I just discovered this bug when starting docker and having many interfaces without GWs.
With the proposed change it works fine with me.
